### PR TITLE
Fix/prettier eslint output

### DIFF
--- a/src/workers/prettier/lint.js
+++ b/src/workers/prettier/lint.js
@@ -205,7 +205,7 @@ const lintContents = async (contents, type, fix = false) => {
           if (result.results[0]) {
             switch (type) {
               case 'es':
-                // 当源码没有需要 fix 的问题时，eslint 的结果会里没有 output
+                // 当源码没有需要 fix 的问题时，eslint 的结果里没有 output 这个字段
                 lintOutput = result.results[0].output
                 break
               case 'style':

--- a/src/workers/prettier/lint.js
+++ b/src/workers/prettier/lint.js
@@ -200,16 +200,21 @@ const lintContents = async (contents, type, fix = false) => {
           linterSuccess = linterSuccess && result.success
           results.push(...result.results)
 
+          let lintOutput
+
           if (result.results[0]) {
             switch (type) {
               case 'es':
-                output = result.results[0].output
+                // 当源码没有需要 fix 的问题时，eslint 的结果会里没有 output
+                lintOutput = result.results[0].output
                 break
               case 'style':
-                output = result.outputs[0]
+                lintOutput = result.outputs[0]
                 break
             }
           }
+
+          output = lintOutput || output
         }
 
         const isDifferent = output !== content.fileContent


### PR DESCRIPTION
修复 prettier 的 fix 模式下，如果 prettier 格式化后的代码在 eslint 里没有需要被 fix 的地方，eslint 的返回值里 `output` 字段为空，导致无法到获取格式化后的结果